### PR TITLE
Make links clickable by using a zero width space.

### DIFF
--- a/gwm_create_service_account.py
+++ b/gwm_create_service_account.py
@@ -40,7 +40,7 @@ from httplib2 import Http
 from google.auth.exceptions import RefreshError
 from google.oauth2 import service_account
 
-VERSION = "1"
+VERSION = "2"
 
 # GCP project IDs must only contain lowercase letters, digits, or hyphens.
 # Projct IDs must start with a letter. Spaces or punctuation are not allowed.
@@ -97,6 +97,8 @@ OAUTH_CONSENT_SCREEN_URL_FORMAT = ("https://console.cloud.google.com/apis/"
 CREATE_OAUTH_WEB_CLIENT_ID_URL = ("https://support.google.com/workspacemigrate/"
                                  "answer/9222992")
 
+# Zero width space character, to be used to separate URLs from punctuation.
+ZWSP = "\u200b"
 
 async def create_project():
   logging.info("Creating project...")
@@ -477,8 +479,8 @@ async def main():
       "account\n5. Create a service account key\n\nIn the end, you will be "
       "prompted to download the service account key. This key can then be used "
       f"for {TOOL_NAME}.\n\nIf you would like to perform these steps manually, "
-      f"then you can follow the instructions at <{TOOL_HELP_CENTER_URL}>.\n\n"
-      "Press Enter to continue or 'n' to exit:")
+      f"then you can follow the instructions at {TOOL_HELP_CENTER_URL}{ZWSP}."
+      "\n\nPress Enter to continue or 'n' to exit:")
 
   if response.lower() == "n":
     sys.exit(0)
@@ -504,8 +506,9 @@ async def main():
   project_id = await get_project_id()
   print("\nNext, follow the instructions to create the OAuth web client "
         f"ID for project {project_id}. You can create this by going to "
-        f"<{OAUTH_CONSENT_SCREEN_URL_FORMAT.format(project_id)}>. The "
-        f"instructions can be found here: <{CREATE_OAUTH_WEB_CLIENT_ID_URL}>.\n")
+        f"{OAUTH_CONSENT_SCREEN_URL_FORMAT.format(project_id)}{ZWSP}. The "
+        "instructions can be found here: "
+        f"{CREATE_OAUTH_WEB_CLIENT_ID_URL}{ZWSP}.\n")
 
 if __name__ == "__main__":
   asyncio.run(main())

--- a/gwmme_create_service_account.py
+++ b/gwmme_create_service_account.py
@@ -73,6 +73,8 @@ USER_AGENT = f"{TOOL_NAME}_create_service_account_v{VERSION}"
 KEY_FILE = (f"{pathlib.Path.home()}/{TOOL_NAME.lower()}-service-account-key-"
             f"{datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}.json")
 
+# Zero width space character, to be used to separate URLs from punctuation.
+ZWSP = "\u200b"
 
 async def create_project():
   logging.info("Creating project...")
@@ -450,8 +452,8 @@ async def main():
       "account\n5. Create a service account key\n\nIn the end, you will be "
       "prompted to download the service account key. This key can then be used "
       f"for {TOOL_NAME}.\n\nIf you would like to perform these steps manually, "
-      f"then you can follow the instructions at {TOOL_HELP_CENTER_URL}.\n\n"
-      "Press Enter to continue or 'n' to exit:")
+      f"then you can follow the instructions at {TOOL_HELP_CENTER_URL}{ZWSP}."
+      "\n\nPress Enter to continue or 'n' to exit:")
 
   if response.lower() == "n":
     sys.exit(0)

--- a/password_sync_create_service_account.py
+++ b/password_sync_create_service_account.py
@@ -41,7 +41,7 @@ from httplib2 import Http
 from google.auth.exceptions import RefreshError
 from google.oauth2 import service_account
 
-VERSION = "1"
+VERSION = "2"
 
 # GCP project IDs must only contain lowercase letters, digits, or hyphens.
 # Projct IDs must start with a letter. Spaces or punctuation are not allowed.
@@ -62,6 +62,8 @@ USER_AGENT = f"{TOOL_NAME}_create_service_account_v{VERSION}"
 KEY_FILE = (f"{pathlib.Path.home()}/{TOOL_NAME.lower()}-service-account-key-"
             f"{datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}.json")
 
+# Zero width space character, to be used to separate URLs from punctuation.
+ZWSP = "\u200b"
 
 async def create_project():
   logging.info("Creating project...")
@@ -439,8 +441,8 @@ async def main():
       "account\n5. Create a service account key\n\nIn the end, you will be "
       "prompted to download the service account key. This key can then be used "
       f"for {TOOL_NAME}.\n\nIf you would like to perform these steps manually, "
-      f"then you can follow the instructions at {TOOL_HELP_CENTER_URL}.\n\n"
-      "Press Enter to continue or 'n' to exit:")
+      f"then you can follow the instructions at {TOOL_HELP_CENTER_URL}{ZWSP}."
+      "\n\nPress Enter to continue or 'n' to exit:")
 
   if response.lower() == "n":
     sys.exit(0)


### PR DESCRIPTION
Wrapping links in `<>` makes them non-clickable in Cloud Shell now, and if we don't wrap them, Cloud Shell would think that the punctuation following them is part of the URL to make clickable.

Based on my testing, the solution is to add a zero width space, making Cloud Shell linkify only the URL itself.