### PR TITLE
Automatically fix org policies that prevent service account key creation

### DIFF
--- a/gwm_create_service_account.py
+++ b/gwm_create_service_account.py
@@ -315,8 +315,8 @@ async def verify_api_access():
         # Admin SDK does not have a corresponding service.
         api_name = "Admin SDK"
         raw_api_response = execute_api_request(
-            "https://www.googleapis.com/admin/directory/v1/users/"
-            f"{admin_user_email}?fields=isAdmin", token)
+            f"https://content-admin.googleapis.com/admin/directory/v1/users/{admin_user_email}?fields=isAdmin",
+            token)
       if api == "calendar-json.googleapis.com":
         api_name = service_name = "Calendar"
         raw_api_response = execute_api_request(
@@ -337,18 +337,15 @@ async def verify_api_access():
       if api == "drive.googleapis.com":
         api_name = service_name = "Drive"
         raw_api_response = execute_api_request(
-            "https://www.googleapis.com/drive/v3/files?pageSize=1&fields=kind",
-            token)
+            "https://www.googleapis.com/drive/v3/files?pageSize=1&fields=kind", token)
       if api == "gmail.googleapis.com":
         api_name = service_name = "Gmail"
         raw_api_response = execute_api_request(
-            "https://gmail.googleapis.com/gmail/v1/users/me/labels?fields=labels.id",
-            token)
+            "https://gmail.googleapis.com/gmail/v1/users/me/labels?fields=labels.id", token)
       if api == "tasks.googleapis.com":
         api_name = service_name = "Tasks"
         raw_api_response = execute_api_request(
-            "https://tasks.googleapis.com/tasks/v1/users/@me/lists?maxResults=1&fields=kind",
-            token)
+            "https://tasks.googleapis.com/tasks/v1/users/@me/lists?maxResults=1&fields=kind", token)
 
       if is_api_disabled(raw_api_response):
         disabled_apis[api_name] = api
@@ -550,7 +547,7 @@ async def get_organization_id():
 def init_logger():
   # Log DEBUG level messages and above to a file
   logging.basicConfig(
-      filename="create_service_account.log",
+      filename=f"{TOOL_NAME}_create_service_account.log",
       format="[%(asctime)s][%(levelname)s] %(message)s",
       datefmt="%FT%TZ",
       level=logging.DEBUG)

--- a/gwm_create_service_account.py
+++ b/gwm_create_service_account.py
@@ -56,14 +56,14 @@ APIS = [
     "contacts.googleapis.com",
     "migrate.googleapis.com",
     "gmail.googleapis.com",
-    "orgpolicy.googleapis.com",
     "calendar-json.googleapis.com",
     "drive.googleapis.com",
     "groupsmigration.googleapis.com",
     "groupssettings.googleapis.com",
     "people.googleapis.com",
     "sheets.googleapis.com",
-    "tasks.googleapis.com"
+    "tasks.googleapis.com",
+    "orgpolicy.googleapis.com"  # This is required by this script.
 ]
 # List of scopes required for service account.
 SCOPES = [
@@ -135,8 +135,8 @@ async def verify_tos_accepted():
                 "Service. You can accept the terms of service by clicking "
                 "https://console.developers.google.com/terms/appsadmin and "
                 "clicking 'Accept'.\n")
-        answer = input("If you've accepted the terms of service, press Enter "
-                       "to try again or 'n' to cancel:")
+        answer = input("\u2753 If you've accepted the terms of service, press "
+                       "Enter to try again or 'n' to cancel: ")
         if answer.lower() == "n":
           sys.exit(0)
       else:
@@ -205,9 +205,9 @@ async def handle_org_policies():
       logging.warning("User %s isn't an org policy admin.", admin_user_email)
       print(
           "The script needs to grant the 'Org Policy Administrator' role to "
-          f"the current user ({admin_user_email}) to proceed.")
-      answer = input("Press Enter to approve this, or 'n' to exit")
-      if response.lower() == "n":
+          f"the current user ({admin_user_email}) to proceed.\n")
+      answer = input("\u2753 Press Enter to approve this, or 'n' to exit: ")
+      if answer.lower() == "n":
         logging.error("The user didn't allow the script to add the role.")
         print(
             "The script can't proceed with creating the required service "
@@ -265,9 +265,9 @@ async def authorize_service_account():
   service_account_id = await get_service_account_id()
   scopes = urllib.parse.quote(",".join(SCOPES), safe="")
   authorize_url = DWD_URL_FORMAT.format(service_account_id, scopes)
-  input(f"\nBefore using {TOOL_NAME_FRIENDLY}, you must authorize the service "
-        "account to perform actions on behalf of your users. You can do so by "
-        f"clicking:\n\n{authorize_url}\n\nAfter clicking 'Authorize', return "
+  input(f"\n\u2753 Before using {TOOL_NAME_FRIENDLY}, you must authorize the "
+        "service account to perform actions on behalf of your users. Visit "
+        f"this link:\n\n{authorize_url}\n\nAfter clicking 'Authorize', return "
         "here and press Enter to continue.")
 
 
@@ -297,8 +297,9 @@ async def verify_service_account_authorization():
             "generally takes less than 1 hour. However, in rare cases, it can "
             "take up to 24 hours.")
       print(f"\n{authorize_url}\n")
-      answer = input("Press Enter to try again, 'c' to continue, or 'n' to "
-                     "cancel:")
+      answer = input(
+          "\u2753 "
+          "Press Enter to try again, 'c' to continue, or 'n' to cancel: ")
       if answer.lower == "c":
         scopes_are_authorized = True
       if answer.lower() == "n":
@@ -388,8 +389,9 @@ async def verify_api_access():
             "https://admin.google.com/ac/appslist/core{ZWSP}.\n")
 
     if retry_api_verification:
-      answer = input("Press Enter to try again, 'c' to continue, or 'n' to "
-                     "cancel:")
+      answer = input(
+          "\u2753 "
+          "Press Enter to try again, 'c' to continue, or 'n' to cancel: ")
       if answer.lower() == "c":
         retry_api_verification = False
       if answer.lower() == "n":
@@ -587,7 +589,7 @@ async def main():
       f"This key can then be used for {TOOL_NAME}.\n\n"
       "If you would like to perform these steps manually, then you can follow "
       f"the instructions at {TOOL_HELP_CENTER_URL}{ZWSP}."
-      "\n\nPress Enter to continue or 'n' to exit:")
+      "\n\nPress Enter to continue or 'n' to exit: ")
 
   if response.lower() == "n":
     sys.exit(0)

--- a/gwm_create_service_account.py
+++ b/gwm_create_service_account.py
@@ -520,7 +520,7 @@ async def retryable_command(command,
     elif suppress_errors:
       return (stdout, stderr, return_code)
     else:
-      logging.critical("Failed to execute command: `%s`", stderr.decode())
+      logging.critical("Failed to execute command: %s\n\nstderr:\n`%s`", stderr.decode())
       sys.exit(return_code)
 
 

--- a/gwm_create_service_account.py
+++ b/gwm_create_service_account.py
@@ -256,8 +256,11 @@ async def create_service_account():
 async def create_service_account_key():
   logging.info("Creating service acount key...")
   service_account_email = await get_service_account_email()
+  # Allowing for a long set of retries because if the org policies on the
+  # project were changed, it could take a while for them to apply.
   await retryable_command(f"gcloud iam service-accounts keys create {KEY_FILE} "
-                          f"--iam-account={service_account_email}")
+                          f"--iam-account={service_account_email}",
+                          max_num_retries=20, retry_delay=10)
   logging.info("Service account key successfully created \u2705")
 
 

--- a/gwm_create_service_account.py
+++ b/gwm_create_service_account.py
@@ -100,9 +100,6 @@ OAUTH_CONSENT_SCREEN_URL_FORMAT = (
 CREATE_OAUTH_WEB_CLIENT_ID_URL = (
     "https://support.google.com/workspacemigrate/answer/9222992")
 
-# Zero width space character, to be used to separate URLs from punctuation.
-ZWSP = "\u200b"
-
 async def create_project():
   logging.info("Creating project...")
   project_id = f"{TOOL_NAME.lower()}-{int(time.time() * 1000)}"
@@ -372,8 +369,7 @@ async def verify_api_access():
     if disabled_apis:
       disabled_api_message = (
           "- The {} API is not enabled. Please enable it by clicking "
-          "https://console.developers.google.com/apis/api/{}/overview?project={}"
-          f"{ZWSP}."
+          "https://console.developers.google.com/apis/api/{}/overview?project={}."
       )
       for api_name in disabled_apis:
         api_id = disabled_apis[api_name]
@@ -389,7 +385,7 @@ async def verify_api_access():
       print("\nIf this is expected, then please continue. If this is not "
             "expected, then please ensure that these services are enabled for "
             "your users by visiting "
-            "https://admin.google.com/ac/appslist/core{ZWSP}.\n")
+            "https://admin.google.com/ac/appslist/core.\n")
 
     if retry_api_verification:
       answer = input(
@@ -591,7 +587,7 @@ async def main():
       "In the end, you will be prompted to download the service account key. "
       f"This key can then be used for {TOOL_NAME}.\n\n"
       "If you would like to perform these steps manually, then you can follow "
-      f"the instructions at {TOOL_HELP_CENTER_URL}{ZWSP}."
+      f"the instructions at {TOOL_HELP_CENTER_URL}."
       "\n\nPress Enter to continue or 'n' to exit: ")
 
   if response.lower() == "n":
@@ -619,9 +615,9 @@ async def main():
   project_id = await get_project_id()
   print("\nNext, follow the instructions to create the OAuth web client "
         f"ID for project {project_id}. You can create this by going to "
-        f"{OAUTH_CONSENT_SCREEN_URL_FORMAT.format(project_id)}{ZWSP}. The "
+        f"{OAUTH_CONSENT_SCREEN_URL_FORMAT.format(project_id)}. The "
         "instructions can be found here: "
-        f"{CREATE_OAUTH_WEB_CLIENT_ID_URL}{ZWSP}.\n")
+        f"{CREATE_OAUTH_WEB_CLIENT_ID_URL}.\n")
 
 if __name__ == "__main__":
   asyncio.run(main())

--- a/gwm_create_service_account.py
+++ b/gwm_create_service_account.py
@@ -17,11 +17,12 @@
 This script streamlines the installation of GWM by automating the steps
 required for obtaining a service account key. Specifically, this script will:
 
-1. Create a GCP project.
+1. Create a GCP project
 2. Enable APIs
-3. Create a service account
-4. Authorize the service account
-5. Create and download a service account key
+3. Verify that the org policies allow creating service account keys
+4. Create a service account
+5. Authorize the service account
+6. Create and download a service account key
 """
 
 import asyncio
@@ -40,7 +41,7 @@ from httplib2 import Http
 from google.auth.exceptions import RefreshError
 from google.oauth2 import service_account
 
-VERSION = "2"
+VERSION = "3"
 
 # GCP project IDs must only contain lowercase letters, digits, or hyphens.
 # Projct IDs must start with a letter. Spaces or punctuation are not allowed.
@@ -375,7 +376,7 @@ async def verify_api_access():
       print("\nIf this is expected, then please continue. If this is not "
             "expected, then please ensure that these services are enabled for "
             "your users by visiting "
-            "<https://admin.google.com/ac/appslist/core>.\n")
+            "https://admin.google.com/ac/appslist/core{ZWSP}.\n")
 
     if retry_api_verification:
       answer = input("Press Enter to try again, 'c' to continue, or 'n' to "
@@ -566,12 +567,17 @@ async def main():
   response = input(
       "Welcome! This script will create and authorize the resources that are "
       f"necessary to use {TOOL_NAME_FRIENDLY}. The following steps will be "
-      "performed on your behalf:\n\n1. Create a Google Cloud Platform project\n"
-      "2. Enable APIs\n3. Create a service account\n4. Authorize the service "
-      "account\n5. Create a service account key\n\nIn the end, you will be "
-      "prompted to download the service account key. This key can then be used "
-      f"for {TOOL_NAME}.\n\nIf you would like to perform these steps manually, "
-      f"then you can follow the instructions at {TOOL_HELP_CENTER_URL}{ZWSP}."
+      "performed on your behalf:\n\n"
+      "1. Create a Google Cloud Platform project\n"
+      "2. Enable APIs\n"
+      "3. Verify that the org policies allow creating service account keys\n"
+      "4. Create a service account\n"
+      "5. Authorize the service account\n"
+      "6. Create a service account key\n\n"
+      "In the end, you will be prompted to download the service account key. "
+      f"This key can then be used for {TOOL_NAME}.\n\n"
+      "If you would like to perform these steps manually, then you can follow "
+      f"the instructions at {TOOL_HELP_CENTER_URL}{ZWSP}."
       "\n\nPress Enter to continue or 'n' to exit:")
 
   if response.lower() == "n":

--- a/gwm_create_service_account.py
+++ b/gwm_create_service_account.py
@@ -223,9 +223,19 @@ async def handle_org_policies():
           "'Org Policy Administrator' role granted successfully. \u2705")
 
     for policy in enforced_policies:
-      command = (f"gcloud resource-manager org-policies disable-enforce "
-                 f"{policy} --project={project_id}")
-      await retryable_command(command)
+      if policy.startswith("iam.managed"):
+        command = "gcloud org-policies set-policy /dev/stdin"
+        stdin_text = (f"""
+name: projects/{project_id}/policies/{policy}
+spec:
+  rules:
+    - enforce: false
+""")
+      else:
+        command = (f"gcloud resource-manager org-policies disable-enforce "
+                   f"{policy} --project={project_id}")
+        stdin_text = None
+      await retryable_command(command, stdin=stdin_text)
       logging.info("Policy %s disabled for project %s. \u2705", policy,
                    project_id)
 
@@ -494,15 +504,19 @@ async def retryable_command(command,
                             max_num_retries=3,
                             retry_delay=5,
                             suppress_errors=False,
-                            require_output=False):
+                            require_output=False,
+                            stdin=None):
   num_tries = 1
   while num_tries <= max_num_retries:
     logging.debug("Executing command (attempt %d): %s", num_tries, command)
+    if stdin is not None:
+      logging.debug("stdin: %s", stdin)
     process = await asyncio.create_subprocess_shell(
         command,
+        stdin=asyncio.subprocess.PIPE if stdin else None,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE)
-    stdout, stderr = await process.communicate()
+    stdout, stderr = await process.communicate(input=stdin.encode() if stdin else None)
     return_code = process.returncode
 
     logging.debug("stdout: %s", stdout.decode())
@@ -519,8 +533,12 @@ async def retryable_command(command,
     elif suppress_errors:
       return (stdout, stderr, return_code)
     else:
-      logging.critical("Failed to execute command: %s\n\nstderr:\n`%s`",
-                       command, stderr.decode())
+      if stdin is not None:
+        logging.critical("Failed to execute command: %s\n\nstdin:\n`%s`\n\nstderr:\n`%s`",
+                         command, stdin, stderr.decode())
+      else:
+        logging.critical("Failed to execute command: %s\n\nstderr:\n`%s`",
+                         command, stderr.decode())
       sys.exit(return_code)
 
 

--- a/gwm_create_service_account.py
+++ b/gwm_create_service_account.py
@@ -170,7 +170,7 @@ async def handle_org_policies():
                f"--project={project_id} --effective")
     stdout, _, return_code = await retryable_command(
         command, suppress_errors=True)
-    if return_code == 0 and "enforced: true" in stdout.decode().lower():
+    if return_code == 0 and "enforce: true" in stdout.decode().lower():
       enforced_policies.append(policy)
 
   if not enforced_policies:

--- a/gwm_create_service_account.py
+++ b/gwm_create_service_account.py
@@ -197,21 +197,30 @@ async def handle_org_policies():
           break
 
     if not is_org_admin:
-      logging.warning(
-          "The script needs to grant the 'Org Policy Administrator' role to "
-          "the current user to proceed.")
-      answer = input("Allow the script to add this role? (y/n): ")
-      if answer.lower() != "y":
-        logging.error(
-            "Permission denied. Please grant the 'Org Policy "
-            "Administrator' role to the user and re-run the script.")
-        sys.exit(1)
-
-      command = (
+      add_iam_policy_binding_command = (
           f"gcloud organizations add-iam-policy-binding {organization_id} "
           f"--member=user:{admin_user_email} "
           "--role=roles/orgpolicy.policyAdmin")
-      await retryable_command(command)
+
+      logging.warning("User %s isn't an org policy admin.", admin_user_email)
+      print(
+          "The script needs to grant the 'Org Policy Administrator' role to "
+          f"the current user ({admin_user_email}) to proceed.")
+      answer = input("Press Enter to approve this, or 'n' to exit")
+      if response.lower() == "n":
+        logging.error("The user didn't allow the script to add the role.")
+        print(
+            "The script can't proceed with creating the required service "
+            f"account key without the current user ({admin_user_email}) "
+            "having the 'Org Policy Administrator' role.\n\n"
+            "To resolve this, visit "
+            "https://console.cloud.google.com/iam-admin/iam?organizationId="
+            f"{organization_id} and grant this role, or run this command:\n\n"
+            f"{add_iam_policy_binding_command}\n\n"
+            "Then, run this script again.\n")
+        sys.exit(1)
+
+      await retryable_command(add_iam_policy_binding_command)
       role_added_by_script = True
       logging.info(
           "'Org Policy Administrator' role granted successfully. \u2705")

--- a/gwm_create_service_account.py
+++ b/gwm_create_service_account.py
@@ -94,10 +94,10 @@ DWD_URL_FORMAT = ("https://admin.google.com/ac/owl/domainwidedelegation?"
 USER_AGENT = f"{TOOL_NAME}_create_service_account_v{VERSION}"
 KEY_FILE = (f"{pathlib.Path.home()}/{TOOL_NAME.lower()}-service-account-key-"
             f"{datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}.json")
-OAUTH_CONSENT_SCREEN_URL_FORMAT = ("https://console.cloud.google.com/apis/"
-                                  "credentials/consent?project={}")
-CREATE_OAUTH_WEB_CLIENT_ID_URL = ("https://support.google.com/workspacemigrate/"
-                                 "answer/9222992")
+OAUTH_CONSENT_SCREEN_URL_FORMAT = (
+    "https://console.cloud.google.com/apis/credentials/consent?project={}")
+CREATE_OAUTH_WEB_CLIENT_ID_URL = (
+    "https://support.google.com/workspacemigrate/answer/9222992")
 
 # Zero width space character, to be used to separate URLs from punctuation.
 ZWSP = "\u200b"

--- a/gwm_create_service_account.py
+++ b/gwm_create_service_account.py
@@ -326,7 +326,7 @@ async def verify_api_access():
         # Admin SDK does not have a corresponding service.
         api_name = "Admin SDK"
         raw_api_response = execute_api_request(
-            f"https://content-admin.googleapis.com/admin/directory/v1/users/{admin_user_email}?fields=isAdmin",
+            f"https://admin.googleapis.com/admin/directory/v1/users/{admin_user_email}?fields=isAdmin",
             token)
       if api == "calendar-json.googleapis.com":
         api_name = service_name = "Calendar"

--- a/gwm_create_service_account.py
+++ b/gwm_create_service_account.py
@@ -519,7 +519,8 @@ async def retryable_command(command,
     elif suppress_errors:
       return (stdout, stderr, return_code)
     else:
-      logging.critical("Failed to execute command: %s\n\nstderr:\n`%s`", stderr.decode())
+      logging.critical("Failed to execute command: %s\n\nstderr:\n`%s`",
+                       command, stderr.decode())
       sys.exit(return_code)
 
 

--- a/gwm_create_service_account.py
+++ b/gwm_create_service_account.py
@@ -104,7 +104,7 @@ async def create_project():
   logging.info("Creating project...")
   project_id = f"{TOOL_NAME.lower()}-{int(time.time() * 1000)}"
   project_name = (f"{TOOL_NAME}-"
-                  f"{datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}")
+                  f"{datetime.datetime.now().strftime('%Y%m%d-%H%M%S')}")
   await retryable_command(f"gcloud projects create {project_id} "
                           f"--name {project_name} --set-as-default")
   logging.info("%s successfully created \u2705", project_id)

--- a/gwm_create_service_account.py
+++ b/gwm_create_service_account.py
@@ -586,7 +586,7 @@ async def main():
       "5. Authorize the service account\n"
       "6. Create a service account key\n\n"
       "In the end, you will be prompted to download the service account key. "
-      f"This key can then be used for {TOOL_NAME}.\n\n"
+      f"This key can then be used for {TOOL_NAME_FRIENDLY}.\n\n"
       "If you would like to perform these steps manually, then you can follow "
       f"the instructions at {TOOL_HELP_CENTER_URL}."
       "\n\nPress Enter to continue or 'n' to exit: ")

--- a/gwmme_create_service_account.py
+++ b/gwmme_create_service_account.py
@@ -79,7 +79,7 @@ async def create_project():
   logging.info("Creating project...")
   project_id = f"{TOOL_NAME.lower()}-{int(time.time() * 1000)}"
   project_name = (f"{TOOL_NAME}-"
-                  f"{datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}")
+                  f"{datetime.datetime.now().strftime('%Y%m%d-%H%M%S')}")
   await retryable_command(f"gcloud projects create {project_id} "
                           f"--name {project_name} --set-as-default")
   logging.info("%s successfully created \u2705", project_id)

--- a/gwmme_create_service_account.py
+++ b/gwmme_create_service_account.py
@@ -561,7 +561,7 @@ async def main():
       "5. Authorize the service account\n"
       "6. Create a service account key\n\n"
       "In the end, you will be prompted to download the service account key. "
-      f"This key can then be used for {TOOL_NAME}.\n\n"
+      f"This key can then be used for {TOOL_NAME_FRIENDLY}.\n\n"
       "If you would like to perform these steps manually, then you can follow "
       f"the instructions at {TOOL_HELP_CENTER_URL}."
       "\n\nPress Enter to continue or 'n' to exit: ")

--- a/gwmme_create_service_account.py
+++ b/gwmme_create_service_account.py
@@ -495,7 +495,7 @@ async def retryable_command(command,
     elif suppress_errors:
       return (stdout, stderr, return_code)
     else:
-      logging.critical("Failed to execute command: `%s`", stderr.decode())
+      logging.critical("Failed to execute command: %s\n\nstderr:\n`%s`", stderr.decode())
       sys.exit(return_code)
 
 

--- a/gwmme_create_service_account.py
+++ b/gwmme_create_service_account.py
@@ -145,7 +145,7 @@ async def handle_org_policies():
                f"--project={project_id} --effective")
     stdout, _, return_code = await retryable_command(
         command, suppress_errors=True)
-    if return_code == 0 and "enforced: true" in stdout.decode().lower():
+    if return_code == 0 and "enforce: true" in stdout.decode().lower():
       enforced_policies.append(policy)
 
   if not enforced_policies:
@@ -312,6 +312,12 @@ async def verify_api_access():
         api_name = "Contacts"
         raw_api_response = execute_api_request(
             "https://www.google.com/m8/feeds/contacts/a.com/full/invalid_contact",
+            token)
+      if api == "people.googleapis.com":
+        # People (Contacts) does not have a corresponding service.
+        api_name = "People"
+        raw_api_response = execute_api_request(
+            "https://people.googleapis.com/v1/people/me/connections?pageSize=1&personFields=metadata",
             token)
       if api == "drive.googleapis.com":
         api_name = service_name = "Drive"

--- a/gwmme_create_service_account.py
+++ b/gwmme_create_service_account.py
@@ -198,9 +198,19 @@ async def handle_org_policies():
           "'Org Policy Administrator' role granted successfully. \u2705")
 
     for policy in enforced_policies:
-      command = (f"gcloud resource-manager org-policies disable-enforce "
-                 f"{policy} --project={project_id}")
-      await retryable_command(command)
+      if policy.startswith("iam.managed"):
+        command = "gcloud org-policies set-policy /dev/stdin"
+        stdin_text = (f"""
+name: projects/{project_id}/policies/{policy}
+spec:
+  rules:
+    - enforce: false
+""")
+      else:
+        command = (f"gcloud resource-manager org-policies disable-enforce "
+                   f"{policy} --project={project_id}")
+        stdin_text = None
+      await retryable_command(command, stdin=stdin_text)
       logging.info("Policy %s disabled for project %s. \u2705", policy,
                    project_id)
 
@@ -469,15 +479,19 @@ async def retryable_command(command,
                             max_num_retries=3,
                             retry_delay=5,
                             suppress_errors=False,
-                            require_output=False):
+                            require_output=False,
+                            stdin=None):
   num_tries = 1
   while num_tries <= max_num_retries:
     logging.debug("Executing command (attempt %d): %s", num_tries, command)
+    if stdin is not None:
+      logging.debug("stdin: %s", stdin)
     process = await asyncio.create_subprocess_shell(
         command,
+        stdin=asyncio.subprocess.PIPE if stdin else None,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE)
-    stdout, stderr = await process.communicate()
+    stdout, stderr = await process.communicate(input=stdin.encode() if stdin else None)
     return_code = process.returncode
 
     logging.debug("stdout: %s", stdout.decode())
@@ -494,8 +508,12 @@ async def retryable_command(command,
     elif suppress_errors:
       return (stdout, stderr, return_code)
     else:
-      logging.critical("Failed to execute command: %s\n\nstderr:\n`%s`",
-                       command, stderr.decode())
+      if stdin is not None:
+        logging.critical("Failed to execute command: %s\n\nstdin:\n`%s`\n\nstderr:\n`%s`",
+                         command, stdin, stderr.decode())
+      else:
+        logging.critical("Failed to execute command: %s\n\nstderr:\n`%s`",
+                         command, stderr.decode())
       sys.exit(return_code)
 
 

--- a/gwmme_create_service_account.py
+++ b/gwmme_create_service_account.py
@@ -57,7 +57,7 @@ APIS = [
     "contacts.googleapis.com",
     "gmail.googleapis.com",
     "groupsmigration.googleapis.com",
-    "orgpolicy.googleapis.com"
+    "orgpolicy.googleapis.com"  # This is required by this script.
 ]
 # List of scopes required for service account.
 SCOPES = [
@@ -110,8 +110,8 @@ async def verify_tos_accepted():
                 "Service. You can accept the terms of service by clicking "
                 "https://console.developers.google.com/terms/appsadmin and "
                 "clicking 'Accept'.\n")
-        answer = input("If you've accepted the terms of service, press Enter "
-                       "to try again or 'n' to cancel:")
+        answer = input("\u2753 If you've accepted the terms of service, press "
+                       "Enter to try again or 'n' to cancel: ")
         if answer.lower() == "n":
           sys.exit(0)
       else:
@@ -180,9 +180,9 @@ async def handle_org_policies():
       logging.warning("User %s isn't an org policy admin.", admin_user_email)
       print(
           "The script needs to grant the 'Org Policy Administrator' role to "
-          f"the current user ({admin_user_email}) to proceed.")
-      answer = input("Press Enter to approve this, or 'n' to exit")
-      if response.lower() == "n":
+          f"the current user ({admin_user_email}) to proceed.\n")
+      answer = input("\u2753 Press Enter to approve this, or 'n' to exit: ")
+      if answer.lower() == "n":
         logging.error("The user didn't allow the script to add the role.")
         print(
             "The script can't proceed with creating the required service "
@@ -240,9 +240,9 @@ async def authorize_service_account():
   service_account_id = await get_service_account_id()
   scopes = urllib.parse.quote(",".join(SCOPES), safe="")
   authorize_url = DWD_URL_FORMAT.format(service_account_id, scopes)
-  input(f"\nBefore using {TOOL_NAME_FRIENDLY}, you must authorize the service "
-        "account to perform actions on behalf of your users. You can do so by "
-        f"clicking:\n\n{authorize_url}\n\nAfter clicking 'Authorize', return "
+  input(f"\n\u2753 Before using {TOOL_NAME_FRIENDLY}, you must authorize the "
+        "service account to perform actions on behalf of your users. Visit "
+        f"this link:\n\n{authorize_url}\n\nAfter clicking 'Authorize', return "
         "here and press Enter to continue.")
 
 
@@ -272,8 +272,9 @@ async def verify_service_account_authorization():
             "generally takes less than 1 hour. However, in rare cases, it can "
             "take up to 24 hours.")
       print(f"\n{authorize_url}\n")
-      answer = input("Press Enter to try again, 'c' to continue, or 'n' to "
-                     "cancel:")
+      answer = input(
+          "\u2753 "
+          "Press Enter to try again, 'c' to continue, or 'n' to cancel: ")
       if answer.lower == "c":
         scopes_are_authorized = True
       if answer.lower() == "n":
@@ -363,8 +364,9 @@ async def verify_api_access():
             "https://admin.google.com/ac/appslist/core{ZWSP}.\n")
 
     if retry_api_verification:
-      answer = input("Press Enter to try again, 'c' to continue, or 'n' to "
-                     "cancel:")
+      answer = input(
+          "\u2753 "
+          "Press Enter to try again, 'c' to continue, or 'n' to cancel: ")
       if answer.lower() == "c":
         retry_api_verification = False
       if answer.lower() == "n":
@@ -562,7 +564,7 @@ async def main():
       f"This key can then be used for {TOOL_NAME}.\n\n"
       "If you would like to perform these steps manually, then you can follow "
       f"the instructions at {TOOL_HELP_CENTER_URL}{ZWSP}."
-      "\n\nPress Enter to continue or 'n' to exit:")
+      "\n\nPress Enter to continue or 'n' to exit: ")
 
   if response.lower() == "n":
     sys.exit(0)

--- a/gwmme_create_service_account.py
+++ b/gwmme_create_service_account.py
@@ -494,7 +494,8 @@ async def retryable_command(command,
     elif suppress_errors:
       return (stdout, stderr, return_code)
     else:
-      logging.critical("Failed to execute command: %s\n\nstderr:\n`%s`", stderr.decode())
+      logging.critical("Failed to execute command: %s\n\nstderr:\n`%s`",
+                       command, stderr.decode())
       sys.exit(return_code)
 
 

--- a/gwmme_create_service_account.py
+++ b/gwmme_create_service_account.py
@@ -301,7 +301,7 @@ async def verify_api_access():
         # Admin SDK does not have a corresponding service.
         api_name = "Admin SDK"
         raw_api_response = execute_api_request(
-            f"https://content-admin.googleapis.com/admin/directory/v1/users/{admin_user_email}?fields=isAdmin",
+            f"https://admin.googleapis.com/admin/directory/v1/users/{admin_user_email}?fields=isAdmin",
             token)
       if api == "calendar-json.googleapis.com":
         api_name = service_name = "Calendar"

--- a/gwmme_create_service_account.py
+++ b/gwmme_create_service_account.py
@@ -55,7 +55,8 @@ APIS = [
     "calendar-json.googleapis.com",
     "contacts.googleapis.com",
     "gmail.googleapis.com",
-    "groupsmigration.googleapis.com"
+    "groupsmigration.googleapis.com",
+    "orgpolicy.googleapis.com"
 ]
 # List of scopes required for service account.
 SCOPES = [
@@ -126,6 +127,85 @@ async def enable_apis():
   enable_api_calls = map(enable_api, APIS[1:])
   await asyncio.gather(*enable_api_calls)
   logging.info("APIs successfully enabled \u2705")
+
+
+async def handle_org_policies():
+  """Checks and handles organization policies."""
+  logging.info("Checking organization policies...")
+  project_id = await get_project_id()
+  policies_to_check = [
+      "iam.disableServiceAccountKeyCreation",
+      "iam.managed.disableServiceAccountKeyCreation"
+  ]
+  enforced_policies = []
+
+  for policy in policies_to_check:
+    command = (f"gcloud org-policies describe {policy} "
+               f"--project={project_id} --effective")
+    stdout, _, return_code = await retryable_command(
+        command, suppress_errors=True)
+    if return_code == 0 and "enforced: true" in stdout.decode().lower():
+      enforced_policies.append(policy)
+
+  if not enforced_policies:
+    logging.info("No restrictive organization policies found \u2705")
+    return
+
+  logging.warning("The following organization policies are enforced: %s",
+                  ", ".join(enforced_policies))
+
+  role_added_by_script = False
+  organization_id = await get_organization_id()
+  admin_user_email = await get_admin_user_email()
+  try:
+    command = (f"gcloud organizations get-iam-policy {organization_id} "
+               "--format=json")
+    stdout, _, _ = await retryable_command(command, require_output=True)
+    iam_policy = json.loads(stdout)
+
+    is_org_admin = False
+    for binding in iam_policy.get("bindings", []):
+      if binding.get("role") == "roles/orgpolicy.policyAdmin":
+        if f"user:{admin_user_email}" in binding.get("members", []):
+          is_org_admin = True
+          break
+
+    if not is_org_admin:
+      logging.warning(
+          "The script needs to grant the 'Org Policy Administrator' role to "
+          "the current user to proceed.")
+      answer = input("Allow the script to add this role? (y/n): ")
+      if answer.lower() != "y":
+        logging.error(
+            "Permission denied. Please grant the 'Org Policy "
+            "Administrator' role to the user and re-run the script.")
+        sys.exit(1)
+
+      command = (
+          f"gcloud organizations add-iam-policy-binding {organization_id} "
+          f"--member=user:{admin_user_email} "
+          "--role=roles/orgpolicy.policyAdmin")
+      await retryable_command(command)
+      role_added_by_script = True
+      logging.info(
+          "'Org Policy Administrator' role granted successfully. \u2705")
+
+    for policy in enforced_policies:
+      command = (f"gcloud resource-manager org-policies disable-enforce "
+                 f"{policy} --project={project_id}")
+      await retryable_command(command)
+      logging.info("Policy %s disabled for project %s. \u2705", policy,
+                   project_id)
+
+  finally:
+    if role_added_by_script:
+      command = (
+          f"gcloud organizations remove-iam-policy-binding {organization_id} "
+          f"--member=user:{admin_user_email} "
+          "--role=roles/orgpolicy.policyAdmin")
+      await retryable_command(command, suppress_errors=True)
+      logging.info(
+          "'Org Policy Administrator' role removed successfully. \u2705")
 
 
 async def create_service_account():
@@ -427,6 +507,12 @@ async def get_admin_user_email():
   return admin_user_email.decode().rstrip()
 
 
+async def get_organization_id():
+  command = 'gcloud organizations list --format="value(ID)"'
+  org_id, _, _ = await retryable_command(command, require_output=True)
+  return org_id.decode().rstrip()
+
+
 def init_logger():
   # Log DEBUG level messages and above to a file
   logging.basicConfig(
@@ -463,6 +549,7 @@ async def main():
   await create_project()
   await verify_tos_accepted()
   await enable_apis()
+  await handle_org_policies()
   await create_service_account()
   await authorize_service_account()
   await create_service_account_key()

--- a/gwmme_create_service_account.py
+++ b/gwmme_create_service_account.py
@@ -17,11 +17,12 @@
 This script streamlines the installation of GWMME by automating the steps
 required for obtaining a service account key. Specifically, this script will:
 
-1. Create a GCP project.
+1. Create a GCP project
 2. Enable APIs
-3. Create a service account
-4. Authorize the service account
-5. Create and download a service account key
+3. Verify that the org policies allow creating service account keys
+4. Create a service account
+5. Authorize the service account
+6. Create and download a service account key
 """
 
 import asyncio
@@ -40,7 +41,7 @@ from httplib2 import Http
 from google.auth.exceptions import RefreshError
 from google.oauth2 import service_account
 
-VERSION = "1"
+VERSION = "3"
 
 # GCP project IDs must only contain lowercase letters, digits, or hyphens.
 # Projct IDs must start with a letter. Spaces or punctuation are not allowed.
@@ -344,7 +345,7 @@ async def verify_api_access():
       print("\nIf this is expected, then please continue. If this is not "
             "expected, then please ensure that these services are enabled for "
             "your users by visiting "
-            "https://admin.google.com/ac/appslist/core.\n")
+            "https://admin.google.com/ac/appslist/core{ZWSP}.\n")
 
     if retry_api_verification:
       answer = input("Press Enter to try again, 'c' to continue, or 'n' to "
@@ -535,12 +536,17 @@ async def main():
   response = input(
       "Welcome! This script will create and authorize the resources that are "
       f"necessary to use {TOOL_NAME_FRIENDLY}. The following steps will be "
-      "performed on your behalf:\n\n1. Create a Google Cloud Platform project\n"
-      "2. Enable APIs\n3. Create a service account\n4. Authorize the service "
-      "account\n5. Create a service account key\n\nIn the end, you will be "
-      "prompted to download the service account key. This key can then be used "
-      f"for {TOOL_NAME}.\n\nIf you would like to perform these steps manually, "
-      f"then you can follow the instructions at {TOOL_HELP_CENTER_URL}{ZWSP}."
+      "performed on your behalf:\n\n"
+      "1. Create a Google Cloud Platform project\n"
+      "2. Enable APIs\n"
+      "3. Verify that the org policies allow creating service account keys\n"
+      "4. Create a service account\n"
+      "5. Authorize the service account\n"
+      "6. Create a service account key\n\n"
+      "In the end, you will be prompted to download the service account key. "
+      f"This key can then be used for {TOOL_NAME}.\n\n"
+      "If you would like to perform these steps manually, then you can follow "
+      f"the instructions at {TOOL_HELP_CENTER_URL}{ZWSP}."
       "\n\nPress Enter to continue or 'n' to exit:")
 
   if response.lower() == "n":

--- a/gwmme_create_service_account.py
+++ b/gwmme_create_service_account.py
@@ -231,8 +231,11 @@ async def create_service_account():
 async def create_service_account_key():
   logging.info("Creating service acount key...")
   service_account_email = await get_service_account_email()
+  # Allowing for a long set of retries because if the org policies on the
+  # project were changed, it could take a while for them to apply.
   await retryable_command(f"gcloud iam service-accounts keys create {KEY_FILE} "
-                          f"--iam-account={service_account_email}")
+                          f"--iam-account={service_account_email}",
+                          max_num_retries=20, retry_delay=10)
   logging.info("Service account key successfully created \u2705")
 
 

--- a/gwmme_create_service_account.py
+++ b/gwmme_create_service_account.py
@@ -75,9 +75,6 @@ USER_AGENT = f"{TOOL_NAME}_create_service_account_v{VERSION}"
 KEY_FILE = (f"{pathlib.Path.home()}/{TOOL_NAME.lower()}-service-account-key-"
             f"{datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}.json")
 
-# Zero width space character, to be used to separate URLs from punctuation.
-ZWSP = "\u200b"
-
 async def create_project():
   logging.info("Creating project...")
   project_id = f"{TOOL_NAME.lower()}-{int(time.time() * 1000)}"
@@ -347,8 +344,7 @@ async def verify_api_access():
     if disabled_apis:
       disabled_api_message = (
           "- The {} API is not enabled. Please enable it by clicking "
-          "https://console.developers.google.com/apis/api/{}/overview?project={}"
-          f"{ZWSP}."
+          "https://console.developers.google.com/apis/api/{}/overview?project={}."
       )
       for api_name in disabled_apis:
         api_id = disabled_apis[api_name]
@@ -364,7 +360,7 @@ async def verify_api_access():
       print("\nIf this is expected, then please continue. If this is not "
             "expected, then please ensure that these services are enabled for "
             "your users by visiting "
-            "https://admin.google.com/ac/appslist/core{ZWSP}.\n")
+            "https://admin.google.com/ac/appslist/core.\n")
 
     if retry_api_verification:
       answer = input(
@@ -566,7 +562,7 @@ async def main():
       "In the end, you will be prompted to download the service account key. "
       f"This key can then be used for {TOOL_NAME}.\n\n"
       "If you would like to perform these steps manually, then you can follow "
-      f"the instructions at {TOOL_HELP_CENTER_URL}{ZWSP}."
+      f"the instructions at {TOOL_HELP_CENTER_URL}."
       "\n\nPress Enter to continue or 'n' to exit: ")
 
   if response.lower() == "n":

--- a/gwmme_create_service_account.py
+++ b/gwmme_create_service_account.py
@@ -516,7 +516,7 @@ async def get_organization_id():
 def init_logger():
   # Log DEBUG level messages and above to a file
   logging.basicConfig(
-      filename="create_service_account.log",
+      filename=f"{TOOL_NAME}_create_service_account.log",
       format="[%(asctime)s][%(levelname)s] %(message)s",
       datefmt="%FT%TZ",
       level=logging.DEBUG)

--- a/password_sync_create_service_account.py
+++ b/password_sync_create_service_account.py
@@ -134,7 +134,7 @@ async def handle_org_policies():
                f"--project={project_id} --effective")
     stdout, _, return_code = await retryable_command(
         command, suppress_errors=True)
-    if return_code == 0 and "enforced: true" in stdout.decode().lower():
+    if return_code == 0 and "enforce: true" in stdout.decode().lower():
       enforced_policies.append(policy)
 
   if not enforced_policies:
@@ -301,6 +301,12 @@ async def verify_api_access():
         api_name = "Contacts"
         raw_api_response = execute_api_request(
             "https://www.google.com/m8/feeds/contacts/a.com/full/invalid_contact",
+            token)
+      if api == "people.googleapis.com":
+        # People (Contacts) does not have a corresponding service.
+        api_name = "People"
+        raw_api_response = execute_api_request(
+            "https://people.googleapis.com/v1/people/me/connections?pageSize=1&personFields=metadata",
             token)
       if api == "drive.googleapis.com":
         api_name = service_name = "Drive"

--- a/password_sync_create_service_account.py
+++ b/password_sync_create_service_account.py
@@ -70,7 +70,7 @@ async def create_project():
   logging.info("Creating project...")
   project_id = f"{TOOL_NAME.lower()}-{int(time.time() * 1000)}"
   project_name = (f"{TOOL_NAME}-"
-                  f"{datetime.datetime.now().strftime('%Y%m%d-%H%M%S')}")
+                  f"{datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}")
   await retryable_command(f"gcloud projects create {project_id} "
                           f"--name {project_name} --set-as-default")
   logging.info("%s successfully created \u2705", project_id)

--- a/password_sync_create_service_account.py
+++ b/password_sync_create_service_account.py
@@ -68,7 +68,7 @@ async def create_project():
   logging.info("Creating project...")
   project_id = f"{TOOL_NAME.lower()}-{int(time.time() * 1000)}"
   project_name = (f"{TOOL_NAME}-"
-                  f"{datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}")
+                  f"{datetime.datetime.now().strftime('%Y%m%d-%H%M%S')}")
   await retryable_command(f"gcloud projects create {project_id} "
                           f"--name {project_name} --set-as-default")
   logging.info("%s successfully created \u2705", project_id)

--- a/password_sync_create_service_account.py
+++ b/password_sync_create_service_account.py
@@ -290,7 +290,7 @@ async def verify_api_access():
         # Admin SDK does not have a corresponding service.
         api_name = "Admin SDK"
         raw_api_response = execute_api_request(
-            f"https://content-admin.googleapis.com/admin/directory/v1/users/{admin_user_email}?fields=isAdmin",
+            f"https://admin.googleapis.com/admin/directory/v1/users/{admin_user_email}?fields=isAdmin",
             token)
       if api == "calendar-json.googleapis.com":
         api_name = service_name = "Calendar"

--- a/password_sync_create_service_account.py
+++ b/password_sync_create_service_account.py
@@ -54,7 +54,7 @@ APIS = [
     # If admin.googleapis.com is to be included, then it must be the first in
     # this list.
     "admin.googleapis.com",
-    "orgpolicy.googleapis.com"
+    "orgpolicy.googleapis.com"  # This is required by this script.
 ]
 # List of scopes required for service account.
 SCOPES = ["https://www.googleapis.com/auth/admin.directory.user"]
@@ -99,8 +99,8 @@ async def verify_tos_accepted():
                 "Service. You can accept the terms of service by clicking "
                 "https://console.developers.google.com/terms/appsadmin and "
                 "clicking 'Accept'.\n")
-        answer = input("If you've accepted the terms of service, press Enter "
-                       "to try again or 'n' to cancel:")
+        answer = input("\u2753 If you've accepted the terms of service, press "
+                       "Enter to try again or 'n' to cancel: ")
         if answer.lower() == "n":
           sys.exit(0)
       else:
@@ -169,9 +169,9 @@ async def handle_org_policies():
       logging.warning("User %s isn't an org policy admin.", admin_user_email)
       print(
           "The script needs to grant the 'Org Policy Administrator' role to "
-          f"the current user ({admin_user_email}) to proceed.")
-      answer = input("Press Enter to approve this, or 'n' to exit")
-      if response.lower() == "n":
+          f"the current user ({admin_user_email}) to proceed.\n")
+      answer = input("\u2753 Press Enter to approve this, or 'n' to exit: ")
+      if answer.lower() == "n":
         logging.error("The user didn't allow the script to add the role.")
         print(
             "The script can't proceed with creating the required service "
@@ -229,9 +229,9 @@ async def authorize_service_account():
   service_account_id = await get_service_account_id()
   scopes = urllib.parse.quote(",".join(SCOPES), safe="")
   authorize_url = DWD_URL_FORMAT.format(service_account_id, scopes)
-  input(f"\nBefore using {TOOL_NAME_FRIENDLY}, you must authorize the service "
-        "account to perform actions on behalf of your users. You can do so by "
-        f"clicking:\n\n{authorize_url}\n\nAfter clicking 'Authorize', return "
+  input(f"\n\u2753 Before using {TOOL_NAME_FRIENDLY}, you must authorize the "
+        "service account to perform actions on behalf of your users. Visit "
+        f"this link:\n\n{authorize_url}\n\nAfter clicking 'Authorize', return "
         "here and press Enter to continue.")
 
 
@@ -261,8 +261,9 @@ async def verify_service_account_authorization():
             "generally takes less than 1 hour. However, in rare cases, it can "
             "take up to 24 hours.")
       print(f"\n{authorize_url}\n")
-      answer = input("Press Enter to try again, 'c' to continue, or 'n' to "
-                     "cancel:")
+      answer = input(
+          "\u2753 "
+          "Press Enter to try again, 'c' to continue, or 'n' to cancel: ")
       if answer.lower == "c":
         scopes_are_authorized = True
       if answer.lower() == "n":
@@ -352,8 +353,9 @@ async def verify_api_access():
             "https://admin.google.com/ac/appslist/core{ZWSP}.\n")
 
     if retry_api_verification:
-      answer = input("Press Enter to try again, 'c' to continue, or 'n' to "
-                     "cancel:")
+      answer = input(
+          "\u2753 "
+          "Press Enter to try again, 'c' to continue, or 'n' to cancel: ")
       if answer.lower() == "c":
         retry_api_verification = False
       if answer.lower() == "n":
@@ -551,7 +553,7 @@ async def main():
       f"This key can then be used for {TOOL_NAME}.\n\n"
       "If you would like to perform these steps manually, then you can follow "
       f"the instructions at {TOOL_HELP_CENTER_URL}{ZWSP}."
-      "\n\nPress Enter to continue or 'n' to exit:")
+      "\n\nPress Enter to continue or 'n' to exit: ")
 
   if response.lower() == "n":
     sys.exit(0)

--- a/password_sync_create_service_account.py
+++ b/password_sync_create_service_account.py
@@ -161,21 +161,30 @@ async def handle_org_policies():
           break
 
     if not is_org_admin:
-      logging.warning(
-          "The script needs to grant the 'Org Policy Administrator' role to "
-          "the current user to proceed.")
-      answer = input("Allow the script to add this role? (y/n): ")
-      if answer.lower() != "y":
-        logging.error(
-            "Permission denied. Please grant the 'Org Policy "
-            "Administrator' role to the user and re-run the script.")
-        sys.exit(1)
-
-      command = (
+      add_iam_policy_binding_command = (
           f"gcloud organizations add-iam-policy-binding {organization_id} "
           f"--member=user:{admin_user_email} "
           "--role=roles/orgpolicy.policyAdmin")
-      await retryable_command(command)
+
+      logging.warning("User %s isn't an org policy admin.", admin_user_email)
+      print(
+          "The script needs to grant the 'Org Policy Administrator' role to "
+          f"the current user ({admin_user_email}) to proceed.")
+      answer = input("Press Enter to approve this, or 'n' to exit")
+      if response.lower() == "n":
+        logging.error("The user didn't allow the script to add the role.")
+        print(
+            "The script can't proceed with creating the required service "
+            f"account key without the current user ({admin_user_email}) "
+            "having the 'Org Policy Administrator' role.\n\n"
+            "To resolve this, visit "
+            "https://console.cloud.google.com/iam-admin/iam?organizationId="
+            f"{organization_id} and grant this role, or run this command:\n\n"
+            f"{add_iam_policy_binding_command}\n\n"
+            "Then, run this script again.\n")
+        sys.exit(1)
+
+      await retryable_command(add_iam_policy_binding_command)
       role_added_by_script = True
       logging.info(
           "'Org Policy Administrator' role granted successfully. \u2705")

--- a/password_sync_create_service_account.py
+++ b/password_sync_create_service_account.py
@@ -550,7 +550,7 @@ async def main():
       "5. Authorize the service account\n"
       "6. Create a service account key\n\n"
       "In the end, you will be prompted to download the service account key. "
-      f"This key can then be used for {TOOL_NAME}.\n\n"
+      f"This key can then be used for {TOOL_NAME_FRIENDLY}.\n\n"
       "If you would like to perform these steps manually, then you can follow "
       f"the instructions at {TOOL_HELP_CENTER_URL}."
       "\n\nPress Enter to continue or 'n' to exit: ")

--- a/password_sync_create_service_account.py
+++ b/password_sync_create_service_account.py
@@ -18,11 +18,12 @@ This script streamlines the installation of Password Sync by automating the
 steps required for obtaining a service account key. Specifically, this script
 will:
 
-1. Create a GCP project.
+1. Create a GCP project
 2. Enable APIs
-3. Create a service account
-4. Authorize the service account
-5. Create and download a service account key
+3. Verify that the org policies allow creating service account keys
+4. Create a service account
+5. Authorize the service account
+6. Create and download a service account key
 """
 
 import asyncio
@@ -41,7 +42,7 @@ from httplib2 import Http
 from google.auth.exceptions import RefreshError
 from google.oauth2 import service_account
 
-VERSION = "2"
+VERSION = "3"
 
 # GCP project IDs must only contain lowercase letters, digits, or hyphens.
 # Projct IDs must start with a letter. Spaces or punctuation are not allowed.
@@ -333,7 +334,7 @@ async def verify_api_access():
       print("\nIf this is expected, then please continue. If this is not "
             "expected, then please ensure that these services are enabled for "
             "your users by visiting "
-            "https://admin.google.com/ac/appslist/core.\n")
+            "https://admin.google.com/ac/appslist/core{ZWSP}.\n")
 
     if retry_api_verification:
       answer = input("Press Enter to try again, 'c' to continue, or 'n' to "
@@ -524,12 +525,17 @@ async def main():
   response = input(
       "Welcome! This script will create and authorize the resources that are "
       f"necessary to use {TOOL_NAME_FRIENDLY}. The following steps will be "
-      "performed on your behalf:\n\n1. Create a Google Cloud Platform project\n"
-      "2. Enable APIs\n3. Create a service account\n4. Authorize the service "
-      "account\n5. Create a service account key\n\nIn the end, you will be "
-      "prompted to download the service account key. This key can then be used "
-      f"for {TOOL_NAME}.\n\nIf you would like to perform these steps manually, "
-      f"then you can follow the instructions at {TOOL_HELP_CENTER_URL}{ZWSP}."
+      "performed on your behalf:\n\n"
+      "1. Create a Google Cloud Platform project\n"
+      "2. Enable APIs\n"
+      "3. Verify that the org policies allow creating service account keys\n"
+      "4. Create a service account\n"
+      "5. Authorize the service account\n"
+      "6. Create a service account key\n\n"
+      "In the end, you will be prompted to download the service account key. "
+      f"This key can then be used for {TOOL_NAME}.\n\n"
+      "If you would like to perform these steps manually, then you can follow "
+      f"the instructions at {TOOL_HELP_CENTER_URL}{ZWSP}."
       "\n\nPress Enter to continue or 'n' to exit:")
 
   if response.lower() == "n":

--- a/password_sync_create_service_account.py
+++ b/password_sync_create_service_account.py
@@ -484,7 +484,7 @@ async def retryable_command(command,
     elif suppress_errors:
       return (stdout, stderr, return_code)
     else:
-      logging.critical("Failed to execute command: `%s`", stderr.decode())
+      logging.critical("Failed to execute command: %s\n\nstderr:\n`%s`", stderr.decode())
       sys.exit(return_code)
 
 

--- a/password_sync_create_service_account.py
+++ b/password_sync_create_service_account.py
@@ -483,7 +483,8 @@ async def retryable_command(command,
     elif suppress_errors:
       return (stdout, stderr, return_code)
     else:
-      logging.critical("Failed to execute command: %s\n\nstderr:\n`%s`", stderr.decode())
+      logging.critical("Failed to execute command: %s\n\nstderr:\n`%s`",
+                       command, stderr.decode())
       sys.exit(return_code)
 
 

--- a/password_sync_create_service_account.py
+++ b/password_sync_create_service_account.py
@@ -52,7 +52,8 @@ TOOL_HELP_CENTER_URL = "https://support.google.com/a/answer/7378726"
 APIS = [
     # If admin.googleapis.com is to be included, then it must be the first in
     # this list.
-    "admin.googleapis.com"
+    "admin.googleapis.com",
+    "orgpolicy.googleapis.com"
 ]
 # List of scopes required for service account.
 SCOPES = ["https://www.googleapis.com/auth/admin.directory.user"]
@@ -115,6 +116,85 @@ async def enable_apis():
   enable_api_calls = map(enable_api, APIS[1:])
   await asyncio.gather(*enable_api_calls)
   logging.info("APIs successfully enabled \u2705")
+
+
+async def handle_org_policies():
+  """Checks and handles organization policies."""
+  logging.info("Checking organization policies...")
+  project_id = await get_project_id()
+  policies_to_check = [
+      "iam.disableServiceAccountKeyCreation",
+      "iam.managed.disableServiceAccountKeyCreation"
+  ]
+  enforced_policies = []
+
+  for policy in policies_to_check:
+    command = (f"gcloud org-policies describe {policy} "
+               f"--project={project_id} --effective")
+    stdout, _, return_code = await retryable_command(
+        command, suppress_errors=True)
+    if return_code == 0 and "enforced: true" in stdout.decode().lower():
+      enforced_policies.append(policy)
+
+  if not enforced_policies:
+    logging.info("No restrictive organization policies found \u2705")
+    return
+
+  logging.warning("The following organization policies are enforced: %s",
+                  ", ".join(enforced_policies))
+
+  role_added_by_script = False
+  organization_id = await get_organization_id()
+  admin_user_email = await get_admin_user_email()
+  try:
+    command = (f"gcloud organizations get-iam-policy {organization_id} "
+               "--format=json")
+    stdout, _, _ = await retryable_command(command, require_output=True)
+    iam_policy = json.loads(stdout)
+
+    is_org_admin = False
+    for binding in iam_policy.get("bindings", []):
+      if binding.get("role") == "roles/orgpolicy.policyAdmin":
+        if f"user:{admin_user_email}" in binding.get("members", []):
+          is_org_admin = True
+          break
+
+    if not is_org_admin:
+      logging.warning(
+          "The script needs to grant the 'Org Policy Administrator' role to "
+          "the current user to proceed.")
+      answer = input("Allow the script to add this role? (y/n): ")
+      if answer.lower() != "y":
+        logging.error(
+            "Permission denied. Please grant the 'Org Policy "
+            "Administrator' role to the user and re-run the script.")
+        sys.exit(1)
+
+      command = (
+          f"gcloud organizations add-iam-policy-binding {organization_id} "
+          f"--member=user:{admin_user_email} "
+          "--role=roles/orgpolicy.policyAdmin")
+      await retryable_command(command)
+      role_added_by_script = True
+      logging.info(
+          "'Org Policy Administrator' role granted successfully. \u2705")
+
+    for policy in enforced_policies:
+      command = (f"gcloud resource-manager org-policies disable-enforce "
+                 f"{policy} --project={project_id}")
+      await retryable_command(command)
+      logging.info("Policy %s disabled for project %s. \u2705", policy,
+                   project_id)
+
+  finally:
+    if role_added_by_script:
+      command = (
+          f"gcloud organizations remove-iam-policy-binding {organization_id} "
+          f"--member=user:{admin_user_email} "
+          "--role=roles/orgpolicy.policyAdmin")
+      await retryable_command(command, suppress_errors=True)
+      logging.info(
+          "'Org Policy Administrator' role removed successfully. \u2705")
 
 
 async def create_service_account():
@@ -416,6 +496,12 @@ async def get_admin_user_email():
   return admin_user_email.decode().rstrip()
 
 
+async def get_organization_id():
+  command = 'gcloud organizations list --format="value(ID)"'
+  org_id, _, _ = await retryable_command(command, require_output=True)
+  return org_id.decode().rstrip()
+
+
 def init_logger():
   # Log DEBUG level messages and above to a file
   logging.basicConfig(
@@ -452,6 +538,7 @@ async def main():
   await create_project()
   await verify_tos_accepted()
   await enable_apis()
+  await handle_org_policies()
   await create_service_account()
   await authorize_service_account()
   await create_service_account_key()

--- a/password_sync_create_service_account.py
+++ b/password_sync_create_service_account.py
@@ -220,8 +220,11 @@ async def create_service_account():
 async def create_service_account_key():
   logging.info("Creating service acount key...")
   service_account_email = await get_service_account_email()
+  # Allowing for a long set of retries because if the org policies on the
+  # project were changed, it could take a while for them to apply.
   await retryable_command(f"gcloud iam service-accounts keys create {KEY_FILE} "
-                          f"--iam-account={service_account_email}")
+                          f"--iam-account={service_account_email}",
+                          max_num_retries=20, retry_delay=10)
   logging.info("Service account key successfully created \u2705")
 
 

--- a/password_sync_create_service_account.py
+++ b/password_sync_create_service_account.py
@@ -64,9 +64,6 @@ USER_AGENT = f"{TOOL_NAME}_create_service_account_v{VERSION}"
 KEY_FILE = (f"{pathlib.Path.home()}/{TOOL_NAME.lower()}-service-account-key-"
             f"{datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}.json")
 
-# Zero width space character, to be used to separate URLs from punctuation.
-ZWSP = "\u200b"
-
 async def create_project():
   logging.info("Creating project...")
   project_id = f"{TOOL_NAME.lower()}-{int(time.time() * 1000)}"
@@ -336,8 +333,7 @@ async def verify_api_access():
     if disabled_apis:
       disabled_api_message = (
           "- The {} API is not enabled. Please enable it by clicking "
-          "https://console.developers.google.com/apis/api/{}/overview?project={}"
-          f"{ZWSP}."
+          "https://console.developers.google.com/apis/api/{}/overview?project={}."
       )
       for api_name in disabled_apis:
         api_id = disabled_apis[api_name]
@@ -353,7 +349,7 @@ async def verify_api_access():
       print("\nIf this is expected, then please continue. If this is not "
             "expected, then please ensure that these services are enabled for "
             "your users by visiting "
-            "https://admin.google.com/ac/appslist/core{ZWSP}.\n")
+            "https://admin.google.com/ac/appslist/core.\n")
 
     if retry_api_verification:
       answer = input(
@@ -555,7 +551,7 @@ async def main():
       "In the end, you will be prompted to download the service account key. "
       f"This key can then be used for {TOOL_NAME}.\n\n"
       "If you would like to perform these steps manually, then you can follow "
-      f"the instructions at {TOOL_HELP_CENTER_URL}{ZWSP}."
+      f"the instructions at {TOOL_HELP_CENTER_URL}."
       "\n\nPress Enter to continue or 'n' to exit: ")
 
   if response.lower() == "n":


### PR DESCRIPTION
- Add code to check if there are org policies applied that prevent the creation of service account keys, and if they exist, try to disable them for the project.
- If the current user doesn't have the `roles/orgpolicy.policyAdmin` role, offer to add (and later remove) it automatically. This is only possible if the user is a super admin, but this script should be only run by super admins anyway, in most cases.
- Remove the zero-width spaces - they were added to fix an issue with Cloud Shell's auto-linkification of URLs, but looks like that was fixed, and now the invisible characters were getting added to URLs, making them not work.
- Bump version to 3.
- Make the 3 scripts consistent, to make it easier to merge them in the future, if we want (as suggested in pull request #19). 
- Small style improvements.

Fixes issue #22. 